### PR TITLE
Add include guard and namespace; amplify readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Now, suppose you know the implementation of a class (or a struct) like that:
 class Sheep 
 {
 public:
-    Sheep(string name_) : name{ std::move(name_) } {}
+    Sheep(std::string name_) : name{ std::move(name_) } {}
     
 private:
     // Data
-    string name;
+    std::string name;
     static int TOTAL;
 
     // Functions

--- a/README.md
+++ b/README.md
@@ -4,27 +4,35 @@ Access to private members and methods in C++
 
 ## How to use it
 
-Copy [privablic.h](https://raw.githubusercontent.com/altamic/privablic/master/privablic.h) into your project and `#include "privablic.h"`.
-
-Suppose you know the implementation of a class (or a struct) like that:
+Copy [privablic.h](https://raw.githubusercontent.com/altamic/privablic/master/privablic.h) into your project and `#include "privablic.h"`, and for easy reading, add: 
+```cpp
+using namespace privablic;
+```
+Now, suppose you know the implementation of a class (or a struct) like that:
 
 ```cpp
-class Sheep {
-  public:
-    Sheep(string name) { this->name = name; };
-  private:
+class Sheep 
+{
+public:
+    Sheep(string name_) : name{ std::move(name_) } {}
+    
+private:
+    // Data
     string name;
-    void baa() { cout << name << ": Baa! Baa!" << endl; };
     static int TOTAL;
-    static void FlockCount() {
-      cout << "sheperd actually counted " <<
-      TOTAL << " sheeps" << endl;
+
+    // Functions
+    void baa() { std::cout << name << ": Baa! Baa!\n"; };
+    
+    static void FlockCount() 
+    {
+      std::cout << "sheperd actually counted " << TOTAL << " sheep\n";
     }
 };
 
 int Sheep::TOTAL = 42;
 ```
-you only have to map some stubs according to types of members and/or methods signatures:
+You only have to map some stubs according to types of members and/or methods signatures:
 
 ### Instance Member
 ```cpp
@@ -50,8 +58,7 @@ struct Sheep_FlockCount { typedef void(*type)(); };
 template class private_method<Sheep_FlockCount, &Sheep::FlockCount>;
 ```
 
-just obtain a Sheep:
-
+Then, using an instance of `Sheep`, you can access the private members like this:
 ```cpp
 Sheep dolly = Sheep("Dolly");
 
@@ -85,20 +92,18 @@ Works under OSX
 
 ## gcc
 
-Unkwown (please try and pull request to let me know :)
+GCC 7.x (at least!)
 
 ## msvc
 
-Unkwown (please try and pull request to let me know :)
+Visual Studio 2019 (at least!)
 
 
 # Credits
 
-[Johannes Schaub (litb)](http://bloglitb.blogspot.com/2010/07/access-to-private-members-thats-easy.html)
-
-[Dave Abrahams](https://gist.github.com/dabrahams/1528856)
-
-[Christof Warlich](http://bloglitb.blogspot.it/2010/07/access-to-private-members-thats-easy.html?showComment=1461746009339#c7258461447914486699)
+* [Johannes Schaub (litb)](http://bloglitb.blogspot.com/2010/07/access-to-private-members-thats-easy.html)
+* [Dave Abrahams](https://gist.github.com/dabrahams/1528856)
+* [Christof Warlich](http://bloglitb.blogspot.it/2010/07/access-to-private-members-thats-easy.html?showComment=1461746009339#c7258461447914486699)
 
 
 # License

--- a/privablic.h
+++ b/privablic.h
@@ -1,3 +1,8 @@
+#ifndef INCLUDED_PRIVABLIC_H
+#define INCLUDED_PRIVABLIC_H
+
+namespace privablic 
+{  
 // Generate a static data member of type Stub::type in which to store
 // the address of a private member.  It is crucial that Stub does not
 // depend on the /value/ of the the stored address in any way so that
@@ -45,4 +50,5 @@ struct private_method : func<Stub> {
 
 template<typename Stub, typename Stub::type p>
 typename private_method<Stub, p>::_private_method private_method<Stub, p>::private_method_obj;
-
+}
+#endif


### PR DESCRIPTION
I followed more of the best practices in library distribution -- don't pollute the global namespace and protect against duplicate inclusion.

I updated the docs a little.